### PR TITLE
Unify OPENAI env variable

### DIFF
--- a/examples/demo_dashboard.py
+++ b/examples/demo_dashboard.py
@@ -53,7 +53,7 @@ with col2:
     st.markdown("""
     - **SFM-2**: Run training script to load model
     - **GPT-2 LoRA**: Load pre-trained adapter
-    - **OpenAI**: Set `your_openai_api_key_here` environment variable
+    - **OpenAI**: Set `OPENAI_API_KEY` environment variable
     """)
 
 # Main Inference Section
@@ -161,7 +161,7 @@ with col2:
     python scripts/train_sfm2.py
     
     # 2. Set OpenAI key (optional)
-    set your_openai_api_key_here=your_key_here
+    set OPENAI_API_KEY=your_key_here
     
     # 3. Start API server
     python -m uvicorn api.app:app --reload

--- a/src/sfm2/api/app.py
+++ b/src/sfm2/api/app.py
@@ -22,11 +22,11 @@ def openai_generate(prompt: str, prompt_type: str) -> str:
     """Generate text using OpenAI API as fallback."""
     try:
         import openai
-        api_key = os.getenv('your_openai_api_key_here')
+        api_key = os.getenv('OPENAI_API_KEY')
         
         if not api_key:
             return ("OpenAI API key not configured. "
-                   "Please set your_openai_api_key_here environment variable.")
+                   "Please set OPENAI_API_KEY environment variable.")
         
         client = openai.OpenAI(api_key=api_key)
         

--- a/src/sfm2/core/model_manager.py
+++ b/src/sfm2/core/model_manager.py
@@ -31,7 +31,7 @@ class ModelManager:
                 model['healthy'] = True
             elif name == 'openai':
                 # Placeholder: check quota or API key
-                model['quota_ok'] = bool(os.getenv('your_openai_api_key_here'))
+                model['quota_ok'] = bool(os.getenv('OPENAI_API_KEY'))
         logger.info(f"Model health: {self.models}")
 
     def intelligent_routing(self, prompt_type: str, complexity: str = 'auto') -> str:

--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -61,7 +61,7 @@ def test_api():
     
     print("\n✅ API tests completed!")
     print("\n💡 To enable OpenAI fallback:")
-    print("   Set environment variable: your_openai_api_key_here=your_key_here")
+    print("   Set environment variable: OPENAI_API_KEY=your_key_here")
     print("   Then restart the API server")
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- use `OPENAI_API_KEY` consistently across the codebase
- update tests and example dashboard instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6847b22dc2e08329ab1f8fc1da549f0b