### PR TITLE
Add CLI interfaces for training and evaluation

### DIFF
--- a/src/sfm2/training/evaluation.py
+++ b/src/sfm2/training/evaluation.py
@@ -7,54 +7,69 @@ Evaluates SFM-2 model on BLEU, syntax accuracy, and function completion rate.
 """
 import os
 import json
+import argparse
 from glob import glob
 from transformers import GPT2LMHeadModel, PreTrainedTokenizerFast
 from nltk.translate.bleu_score import sentence_bleu, SmoothingFunction
 
-MODEL_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../models/sfm-2/'))
-TOKENIZER_PATH = os.path.join(MODEL_DIR, 'tokenizer.json')
-DATA_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../datasets/cleaned/'))
-RESULTS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), 'sfm2_eval_results.json'))
+MODEL_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../models/sfm-2/"))
+TOKENIZER_PATH = os.path.join(MODEL_DIR, "tokenizer.json")
+DATA_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../datasets/cleaned/"))
+RESULTS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "sfm2_eval_results.json"))
 
-model = GPT2LMHeadModel.from_pretrained(MODEL_DIR)
-tokenizer = PreTrainedTokenizerFast(tokenizer_file=TOKENIZER_PATH)
-model.eval()
 
-bleu_scores = []
-syntax_correct = 0
-func_complete = 0
-n = 0
+def evaluate(model_dir, tokenizer_path, data_dir, results_path):
+    """Run the evaluation loop."""
+    model = GPT2LMHeadModel.from_pretrained(model_dir)
+    tokenizer = PreTrainedTokenizerFast(tokenizer_file=tokenizer_path)
+    model.eval()
 
-for file in glob(os.path.join(DATA_DIR, '*.sona')):
-    with open(file, 'r', encoding='utf-8') as f:
-        ref = f.read().strip()
-    if len(ref) < 20:
-        continue
-    # Generate output
-    inputs = tokenizer(ref, return_tensors='pt')
-    output_ids = model.generate(
-        inputs['input_ids'],
-        max_length=inputs['input_ids'].shape[1] + 64,
-        do_sample=False
-    )
-    gen = tokenizer.decode(output_ids[0], skip_special_tokens=True)
-    # BLEU
-    bleu = sentence_bleu([ref.split()], gen.split(), smoothing_function=SmoothingFunction().method1)
-    bleu_scores.append(bleu)
-    # Syntax check (very basic)
-    if gen.count('{') == gen.count('}') and gen.count('(') == gen.count(')'):
-        syntax_correct += 1
-    # Function completion (checks for 'fn' and closing brace)
-    if 'fn' in gen and gen.strip().endswith('}'): 
-        func_complete += 1
-    n += 1
+    bleu_scores = []
+    syntax_correct = 0
+    func_complete = 0
+    n = 0
 
-results = {
-    'bleu_mean': sum(bleu_scores)/max(1, len(bleu_scores)),
-    'syntax_accuracy': syntax_correct/max(1, n),
-    'function_completion_rate': func_complete/max(1, n),
-    'samples': n
-}
-with open(RESULTS_PATH, 'w') as f:
-    json.dump(results, f, indent=2)
-print(f"✅ SFM-2 evaluation complete. Results saved to {RESULTS_PATH}")
+    for file in glob(os.path.join(data_dir, "*.sona")):
+        with open(file, "r", encoding="utf-8") as f:
+            ref = f.read().strip()
+        if len(ref) < 20:
+            continue
+        inputs = tokenizer(ref, return_tensors="pt")
+        output_ids = model.generate(
+            inputs["input_ids"], max_length=inputs["input_ids"].shape[1] + 64, do_sample=False
+        )
+        gen = tokenizer.decode(output_ids[0], skip_special_tokens=True)
+        bleu = sentence_bleu([ref.split()], gen.split(), smoothing_function=SmoothingFunction().method1)
+        bleu_scores.append(bleu)
+        if gen.count("{") == gen.count("}") and gen.count("(") == gen.count(")"):
+            syntax_correct += 1
+        if "fn" in gen and gen.strip().endswith("}"):
+            func_complete += 1
+        n += 1
+
+    results = {
+        "bleu_mean": sum(bleu_scores) / max(1, len(bleu_scores)),
+        "syntax_accuracy": syntax_correct / max(1, n),
+        "function_completion_rate": func_complete / max(1, n),
+        "samples": n,
+    }
+    with open(results_path, "w", encoding="utf-8") as f:
+        json.dump(results, f, indent=2)
+
+    print(f"✅ SFM-2 evaluation complete. Results saved to {results_path}")
+
+
+def main(argv=None):
+    """Entry point for the ``sfm2-evaluate`` console script."""
+    parser = argparse.ArgumentParser(description="Evaluate a trained SFM-2 model")
+    parser.add_argument("--model-dir", default=MODEL_DIR, help="Directory containing the trained model")
+    parser.add_argument("--tokenizer", default=TOKENIZER_PATH, help="Path to the tokenizer file")
+    parser.add_argument("--data-dir", default=DATA_DIR, help="Directory of evaluation data")
+    parser.add_argument("--output", default=RESULTS_PATH, help="File to write evaluation metrics")
+    args = parser.parse_args(argv)
+
+    evaluate(args.model_dir, args.tokenizer, args.data_dir, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sfm2/training/pipeline.py
+++ b/src/sfm2/training/pipeline.py
@@ -9,72 +9,115 @@ Trains a GPT-2 style model for Sona code generation using the cleaned dataset an
 - Includes TODOs for distributed training, logging, and advanced metrics
 """
 import os
-from glob import glob
-from transformers import GPT2Config, GPT2LMHeadModel, Trainer, TrainingArguments, PreTrainedTokenizerFast, TextDataset, DataCollatorForLanguageModeling
 import json
+import argparse
+from glob import glob
+from transformers import (
+    GPT2Config,
+    GPT2LMHeadModel,
+    Trainer,
+    TrainingArguments,
+    PreTrainedTokenizerFast,
+    TextDataset,
+    DataCollatorForLanguageModeling,
+)
 
-CONFIG_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../configs/sfm2_config.json'))
-TOKENIZER_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../tokenizers/sona-tokenizer.json'))
-DATA_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../datasets/cleaned/'))
-MODEL_OUT = os.path.abspath(os.path.join(os.path.dirname(__file__), '../models/sfm-2/'))
-os.makedirs(MODEL_OUT, exist_ok=True)
+CONFIG_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "../configs/sfm2_config.json")
+)
+TOKENIZER_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "../tokenizers/sona-tokenizer.json")
+)
+DATA_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "../datasets/cleaned/")
+)
+MODEL_OUT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "../models/sfm-2/")
+)
 
-# Load config and tokenizer
-with open(CONFIG_PATH, 'r') as f:
-    config_dict = json.load(f)
-config = GPT2Config(**config_dict)
-tokenizer = PreTrainedTokenizerFast(tokenizer_file=TOKENIZER_PATH)
 
 def get_dataset(tokenizer, data_dir):
-    files = glob(os.path.join(data_dir, '*.sona'))
-    with open('train.txt', 'w', encoding='utf-8') as out:
+    """Create a TextDataset from all ``*.sona`` files in ``data_dir``."""
+    files = glob(os.path.join(data_dir, "*.sona"))
+    with open("train.txt", "w", encoding="utf-8") as out:
         for fpath in files:
-            with open(fpath, 'r', encoding='utf-8') as f:
-                out.write(f.read() + '\n')
-    return TextDataset(
-        tokenizer=tokenizer,
-        file_path='train.txt',
-        block_size=1024
+            with open(fpath, "r", encoding="utf-8") as f:
+                out.write(f.read() + "\n")
+    return TextDataset(tokenizer=tokenizer, file_path="train.txt", block_size=1024)
+
+
+def train(config_path, tokenizer_path, data_dir, model_out):
+    """Run the training loop."""
+    os.makedirs(model_out, exist_ok=True)
+
+    with open(config_path, "r", encoding="utf-8") as f:
+        config_dict = json.load(f)
+
+    config = GPT2Config(**config_dict)
+    tokenizer = PreTrainedTokenizerFast(tokenizer_file=tokenizer_path)
+
+    dataset = get_dataset(tokenizer, data_dir)
+    data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
+
+    model = GPT2LMHeadModel(config)
+
+    training_args = TrainingArguments(
+        output_dir=model_out,
+        overwrite_output_dir=True,
+        num_train_epochs=5,
+        per_device_train_batch_size=2,
+        save_steps=500,
+        save_total_limit=3,
+        prediction_loss_only=True,
+        logging_steps=50,
+        evaluation_strategy="steps",
+        eval_steps=500,
+        learning_rate=5e-5,
+        warmup_steps=1000,
+        weight_decay=0.01,
+        gradient_accumulation_steps=2,
+        fp16=True,
+        report_to=[],
+        # TODO: Add distributed training, advanced logging, and callbacks
     )
 
-dataset = get_dataset(tokenizer, DATA_DIR)
-data_collator = DataCollatorForLanguageModeling(
-    tokenizer=tokenizer, mlm=False
-)
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=dataset,
+        eval_dataset=None,  # TODO: Add validation split
+        data_collator=data_collator,
+    )
 
-model = GPT2LMHeadModel(config)
+    trainer.train()
+    model.save_pretrained(model_out)
+    tokenizer.save_pretrained(model_out)
+    print(f"✅ SFM-2 model trained and saved to {model_out}")
+    # TODO: Add BLEU, syntax accuracy, and function completion metrics
+    # TODO: Add early stopping, advanced eval, and distributed support
 
-training_args = TrainingArguments(
-    output_dir=MODEL_OUT,
-    overwrite_output_dir=True,
-    num_train_epochs=5,
-    per_device_train_batch_size=2,
-    save_steps=500,
-    save_total_limit=3,
-    prediction_loss_only=True,
-    logging_steps=50,
-    evaluation_strategy='steps',
-    eval_steps=500,
-    learning_rate=5e-5,
-    warmup_steps=1000,
-    weight_decay=0.01,
-    gradient_accumulation_steps=2,
-    fp16=True,
-    report_to=[],
-    # TODO: Add distributed training, advanced logging, and callbacks
-)
 
-trainer = Trainer(
-    model=model,
-    args=training_args,
-    train_dataset=dataset,
-    eval_dataset=None,  # TODO: Add validation split
-    data_collator=data_collator,
-)
+def main(argv=None):
+    """Entry point for the ``sfm2-train`` console script."""
+    parser = argparse.ArgumentParser(description="Train the SFM-2 model")
+    parser.add_argument(
+        "--config", default=CONFIG_PATH, help="Path to the model configuration JSON"
+    )
+    parser.add_argument(
+        "--tokenizer", default=TOKENIZER_PATH, help="Path to the tokenizer file"
+    )
+    parser.add_argument(
+        "--data-dir",
+        default=DATA_DIR,
+        help="Directory containing training data (.sona files)",
+    )
+    parser.add_argument(
+        "--model-out", default=MODEL_OUT, help="Directory to save the trained model"
+    )
+    args = parser.parse_args(argv)
 
-trainer.train()
-model.save_pretrained(MODEL_OUT)
-tokenizer.save_pretrained(MODEL_OUT)
-print(f"✅ SFM-2 model trained and saved to {MODEL_OUT}")
-# TODO: Add BLEU, syntax accuracy, and function completion metrics
-# TODO: Add early stopping, advanced eval, and distributed support
+    train(args.config, args.tokenizer, args.data_dir, args.model_out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- define `main()` functions in training pipeline and evaluation
- allow command line arguments for paths
- enable console scripts `sfm2-train` and `sfm2-evaluate`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6847b2c0c4048329b7d1f86b92962666