### PR TITLE
Add missing research methodology doc

### DIFF
--- a/docs/RESEARCH_METHODOLOGY.md
+++ b/docs/RESEARCH_METHODOLOGY.md
@@ -1,0 +1,33 @@
+# Research Methodology
+
+SFM-2 is built from the ground up with a focus on understanding and generating programming languages. This document summarizes the methodology used during research and development.
+
+## Objectives
+
+- Develop syntax-aware attention mechanisms tailored for source code
+- Evaluate model performance across multiple programming tasks
+- Provide a production-ready API with intelligent fallback systems
+- Maintain a reproducible training and validation pipeline
+
+## Approach
+
+1. **Syntax-aware Model Design**
+   - Utilize Abstract Syntax Trees (AST) to guide attention patterns
+   - Incorporate token type and scope information into embeddings
+2. **Systematic Evaluation**
+   - Functional correctness tests for generated code
+   - Syntactic validity and style checks
+   - Benchmarks covering completion, explanation and refactoring tasks
+3. **API and Fallback Architecture**
+   - RESTful API built with FastAPI
+   - Automatic fallback chain: SFM-2 → GPT-2 LoRA → OpenAI models
+   - Health monitoring and detailed error reporting
+4. **Training Pipeline**
+   - Configurable datasets and hyperparameters
+   - Early stopping and gradient accumulation support
+   - Logging and metrics with TensorBoard
+
+## Reproducibility
+
+All experiments are tracked through configuration files under `configs/` and logs produced by the training scripts. Instructions for running the pipeline can be found in the [Training Guide](TRAINING_GUIDE.md).
+


### PR DESCRIPTION
## Summary
- add missing **docs/RESEARCH_METHODOLOGY.md** with methodology overview

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6847b2c83c1c83298e4e426e66af8b33